### PR TITLE
[SINT-4649] Include URL in fetchWithRetry error messages

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,7 +66,7 @@ async function fetchWithRetry(url, options = {}, retries = 3, initialDelay = 100
       }
       return response;
     } catch (error) {
-      console.warn(`Attempt ${attempt} failed. Error: ${error.message}`);
+      console.warn(`Attempt ${attempt} failed for URL: ${url}. Error: ${error.message}`);
       const jitter = Math.floor(Math.random() * 5000);
       const delay = Math.min(2 ** attempt * initialDelay + jitter, 10000); // Limit max delay to 10 seconds
       await new Promise(resolve => setTimeout(resolve, delay));
@@ -74,7 +74,7 @@ async function fetchWithRetry(url, options = {}, retries = 3, initialDelay = 100
       retries--;
     }
   }
-  throw new Error(`Fetch failed after ${attempt} attempts.`);
+  throw new Error(`Fetch failed after ${attempt} attempts for URL: ${url}.`);
 }
 
 function buildExchangeUrl() {


### PR DESCRIPTION
Part of the upstream sync review of octo-sts/action commits behind our fork. [context](https://datadoghq.atlassian.net/wiki/spaces/SECENG/pages/6297682599/octo-sts+upstream+action+decisions)

## Summary

- Adds the failed URL to per-attempt `console.warn` messages in `fetchWithRetry`
- Adds the failed URL to the final exhaustion `throw` in `fetchWithRetry`
- Helps on-call engineers distinguish OIDC provider failures from STS exchange failures during triage

URLs contain only endpoint paths and org/repo names — auth tokens are passed in headers, not URLs, so there is no sensitive data exposure.

## Changes

`index.js` — 2 lines changed in `fetchWithRetry`:
- `console.warn(...)` now includes `for URL: ${url}`
- Final `throw new Error(...)` now includes `for URL: ${url}`

## Test plan

- [x] Verify existing CI workflows pass (no functional change)
- [ ] Manually trigger a failure scenario and confirm the URL appears in the error output


🤖 Generated with [Claude Code](https://claude.com/claude-code)